### PR TITLE
4.7.1 - mmio structs still need regular arrays

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -84,7 +84,7 @@ jobs:
 
       - run: |
           mk python-release owner=libre-embedded \
-                            repo=ifgen version=4.7.0
+                            repo=ifgen version=4.7.1
         if: |
           matrix.python-version == '3.13'
           && matrix.system == 'ubuntu-latest'

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
     =====================================
     generator=datazen
     version=3.2.3
-    hash=38dc9d7a731334f1a9d12c31401efb71
+    hash=b957d8a15d2824b9dfcdfc348dd6b851
     =====================================
 -->
 
-# ifgen ([4.7.0](https://pypi.org/project/ifgen/))
+# ifgen ([4.7.1](https://pypi.org/project/ifgen/))
 
 [![python](https://img.shields.io/pypi/pyversions/ifgen.svg)](https://pypi.org/project/ifgen/)
 ![Build Status](https://github.com/libre-embedded/ifgen/workflows/Python%20Package/badge.svg)

--- a/ifgen/__init__.py
+++ b/ifgen/__init__.py
@@ -1,7 +1,7 @@
 # =====================================
 # generator=datazen
 # version=3.2.3
-# hash=18b776569e15d4363f48bde945c2b0f6
+# hash=415fefcf7736b4ad3c659e0cd455c32e
 # =====================================
 
 """
@@ -10,4 +10,4 @@ Useful defaults and other package metadata.
 
 DESCRIPTION = "An interface generator for distributed computing."
 PKG_NAME = "ifgen"
-VERSION = "4.7.0"
+VERSION = "4.7.1"

--- a/ifgen/struct/header.py
+++ b/ifgen/struct/header.py
@@ -82,7 +82,10 @@ def struct_fields(task: GenerateTask, writer: IndentedFileWriter) -> None:
                 f"{task.name}.{field['name']}",
             )
 
-            if "array_length" in field and task.instance["packed"]:
+            standard_array = task.instance["packed"] or bool(
+                task.instance.get("instances")
+            )
+            if "array_length" in field and standard_array:
                 lines.append(
                     (
                         (
@@ -131,7 +134,7 @@ def struct_fields(task: GenerateTask, writer: IndentedFileWriter) -> None:
                         possible_union,
                         possible_union["volatile"],
                         possible_union["const"],
-                        task.instance["packed"],
+                        standard_array,
                         array_length=possible_union.get("array_length"),
                         default=default,
                     )

--- a/ifgen/struct/methods/common.py
+++ b/ifgen/struct/methods/common.py
@@ -31,6 +31,7 @@ def swap_fields(
                 array_cmp = task.cpp_namespace(
                     f"{name}_length"
                     if task.instance["packed"]
+                    or bool(task.instance.get("instances"))
                     else f"{name}.size()"
                 )
                 writer.write(f"for (std::size_t i = 0; i < {array_cmp}; i++)")

--- a/local/variables/package.yaml
+++ b/local/variables/package.yaml
@@ -1,5 +1,5 @@
 ---
 major: 4
 minor: 7
-patch: 0
+patch: 1
 entry: ig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 
 [project]
 name = "ifgen"
-version = "4.7.0"
+version = "4.7.1"
 description = "An interface generator for distributed computing."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
due to volatile discard on array methods, not an issue with C arrays due to indexing functioning via pointer decomposition?